### PR TITLE
Do not log RDS master password to CloudWatch logs

### DIFF
--- a/cdk-postgresql/lib/util.ts
+++ b/cdk-postgresql/lib/util.ts
@@ -23,8 +23,6 @@ export const getConnectedClient = async (connection: Connection) => {
     database: connection.Database,
   };
 
-  console.debug(`clientProps: ${JSON.stringify(clientProps)}`);
-
   if (connection.SSLMode === "require") {
     clientProps.ssl = {
       rejectUnauthorized: false,


### PR DESCRIPTION
Lambda logs the `ClientConfig` object, which contains the PostgreSQL password. This results in the RDS master password from Secrets Manager plainly visible in CloudWatch logs. This PR removes the log entry.